### PR TITLE
Clean up Build.PL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# Sys::Sendfile
+
+## NOTE: Build.PL
+
+Please note that the `Build.PL` file found in this repo is a template
+and is not intended to be used directly. You should use `Dist::Zilla`
+to manage the building of this software instead (see below).
+
+## Dist::Zilla usage
+
+The distribution is managed with `Dist::Zilla`
+(https://metacpan.org/release/Dist-Zilla).  This means than many of
+the usual files you might expect are not in the repository, but are
+generated at release time (e.g. `Makefile.PL`).
+
+`Dist::Zilla` is a very powerful authoring tool, but requires a number
+of author-specific plugins.  If you would like to use it for
+contributing, install it from CPAN, then run one of the following
+commands, depending on your CPAN client:
+
+    $ cpan `dzil authordeps --missing`
+
+or
+
+    $ dzil authordeps --missing | cpanm
+
+You should then also install any additional requirements not needed by
+the `dzil` build but may be needed by tests or other development:
+
+    $ cpan `dzil listdeps --author --missing`
+
+or
+
+    $ dzil listdeps --author --missing | cpanm
+
+Once installed, here are some dzil commands you might try:
+
+    $ dzil build
+    $ dzil test
+    $ dzil test --release
+    $ dzil xtest
+    $ dzil listdeps --json
+    $ dzil build --notgz
+
+You can learn more about Dist::Zilla at http://dzil.org/.

--- a/dist.ini
+++ b/dist.ini
@@ -4,5 +4,11 @@ license = Perl_5
 copyright_holder = Leon Timmermans
 copyright_year   = 2008
 
-[@LEONT]
+
+[@Filter]
+-bundle = @LEONT
+-remove = GatherDir
 install_tool = mbc
+
+[GatherDir]
+exclude_filename = README.md


### PR DESCRIPTION
Removes the broken Build.PL and adds a README file explaining basic dzil usage.

I considered adding in dzil config to copy the generated Build.PL out of the .build directory, but that seemed more invasive. If you'd prefer that, I'm happy to revise this. Chrs. 

(Part of the CPAN PR challenge.)
